### PR TITLE
Fix handling ConnectionClosedOK exception in Relay._receive_messages()

### DIFF
--- a/aionostr/relay.py
+++ b/aionostr/relay.py
@@ -96,7 +96,7 @@ class Relay:
     async def send(self, message):
         try:
             await self.ws.send(dumps(message))
-        except exceptions.ConnectionClosedError:
+        except exceptions.ConnectionClosed:
             await self.reconnect()
             await self.ws.send(dumps(message))
 

--- a/aionostr/relay.py
+++ b/aionostr/relay.py
@@ -49,9 +49,11 @@ class Relay:
         await asyncio.sleep(0.01)
         self.connected = True
         self.log.info("Connected to %s", self.url)
+        return True
 
     async def reconnect(self):
-        await self.connect(20)
+        while not await self.connect(20):
+            await asyncio.sleep(60*30)
         for sub_id, sub in self.subscriptions.items():
             self.log.debug("resubscribing to %s", sub.filters)
             await self.send(["REQ", sub_id, *sub.filters])

--- a/aionostr/relay.py
+++ b/aionostr/relay.py
@@ -84,7 +84,7 @@ class Relay:
                     sys.stderr.write(message)
             except asyncio.CancelledError:
                 return
-            except exceptions.ConnectionClosedError:
+            except exceptions.ConnectionClosed:
                 await self.reconnect()
             except asyncio.TimeoutError:
                 continue


### PR DESCRIPTION
If a relay closes the connection to aionostr successfully (not due to an error) ```_receive_messages()``` will be stuck in a infinite exception loop and block the event loop as it doesn't catch ```ConnectionClosedOK``` exception, only the ```ConnectionClosedError``` exception.

Example: 
```
Traceback (most recent call last):
File \"/usr/local/lib/python3.9/dist-packages/electrum_aionostr/relay.py\", line 69, in _receive_messages
     message = await asyncio.wait_for(self.ws.recv(), 30.0)
File \"/usr/lib/python3.9/asyncio/tasks.py\", line 481, in wait_for
     return fut.result()
File \"/usr/local/lib/python3.9/dist-packages/websockets/legacy/protocol.py\", line 568, in recv
     await self.ensure_open()
File \"/usr/local/lib/python3.9/dist-packages/websockets/legacy/protocol.py\", line 939, in ensure_open
     raise self.connection_closed_exc()
 websockets.exceptions.ConnectionClosedOK: received 1001 (going away) CloudFlare WebSocket proxy restarting; then sent 1001 (going away) CloudFlare WebSocket proxy restarting
```

This PR changes the except to catch the parent exception ```ConnectionClosed``` which will then attempt to reconnect on  both, 'OK' and 'Error' closes.
Additionally it checks the return value of ```self.connect()``` when called in ```reconnect()``` to prevent trying to send if a connection attempt was unsuccessful, instead it will timeout and try again later after the 20 attempts failed. 